### PR TITLE
Promote buildstation date updates to main

### DIFF
--- a/src/sections/buildstation/berlin-demo-day.tsx
+++ b/src/sections/buildstation/berlin-demo-day.tsx
@@ -43,7 +43,7 @@ const BerlinDemoDay = () => {
           </div>
           <div>
             <ul className='list-disc list-inside space-y-2 px-4'>
-              <li>Local, in real life Demo Day on the 9th of April.</li>
+              <li>Local, in real life Demo Day on the 12th of May.</li>
               <li>Hackathon submissions are eligible to present.</li>
             </ul>
           </div>
@@ -60,7 +60,7 @@ const BerlinDemoDay = () => {
                   href={UPCOMING_HACKATHON_LINK}>
                   Colosseum
                 </Link>
-                {' '}by October 8th at midnight.
+                {' '}by May 11 at midnight.
               </li>
               <li>
                 Apply separately for each side track (e.g., Superteam Germany
@@ -80,7 +80,7 @@ const BerlinDemoDay = () => {
                   href={REGISTER_BUILD_STATION_DEMO_DAY_LINK}>
                   Berlin Demo Day
                 </Link>
-                {' '}is on October 9th. Pitch your project for a
+                {' '}is on May 12. Pitch your project for a
                 chance to win an additional 20K in Germany-only prizes.
               </li>
             </ul>

--- a/src/sections/buildstation/hero.tsx
+++ b/src/sections/buildstation/hero.tsx
@@ -61,8 +61,9 @@ export default function Hero() {
                 devs, marketers, artists and more.
               </p>
               <p className="mt-8 text-xl text-primary font-semibold">
-                Upcoming Hackathon: 25.09.2025 - 30.10.2025! <br />
-                Demo Day: 31.10.2025
+                Upcoming Hackathon: 06.04.2026 - 11.05.2026 <br />
+                Build Station: 27.04.2026 - 11.05.2026 <br />
+                Demo Day: 12.05.2026
               </p>
 
               {/* <NewsletterForm title="RSVP for Buildstation" /> */}

--- a/src/sections/buildstation/how-it-works.tsx
+++ b/src/sections/buildstation/how-it-works.tsx
@@ -151,7 +151,11 @@ export function HowItWorks() {
             How Build Station Works
           </h2>
           <p className="mt-6 font-bold">
-            Build your project online or join us in Berlin. Submit a pitch deck, 3-min demo video, and Github repo by May 16. Not sure where to start? Visit our Co-working Fridays, Workshops, and Build Station.
+            Build your project online or join us in Berlin. The Global
+            Hackathon runs from 06.04.2026 to 11.05.2026, Build Station runs
+            from 27.04.2026 to 11.05.2026, and Demo Day takes place on
+            12.05.2026. Not sure where to start? Visit our Co-working Fridays,
+            Workshops, and Build Station.
           </p>
         </div>
         <CustomTabGroup

--- a/src/sections/buildstation/key-dates.tsx
+++ b/src/sections/buildstation/key-dates.tsx
@@ -10,20 +10,20 @@ import { useScroll, useTransform, motion } from "framer-motion";
 const timelineEvents = [
   {
     id: 1,
-    title: "Hackathon Kickoff",
-    date: "25 Sep 2025",
+    title: "Global Hackathon",
+    date: "06 Apr - 11 May 2026",
     icon: "diamond-blue",
   },
   {
     id: 2,
     title: "Build Station",
-    date: "Oct 20-30 2025",
+    date: "27 Apr - 11 May 2026",
     icon: "diamond-gray",
   },
   {
     id: 3,
     title: "Demo Day",
-    date: "Oct 31 2025",
+    date: "12 May 2026",
     icon: "diamond-gray",
   },
 ];


### PR DESCRIPTION
## Summary
Promote the buildstation date updates from `development` to `main`.

## Includes
- updated Global Hackathon dates
- updated Build Station dates
- updated Demo Day date
- consistent buildstation page copy
