### PR TITLE
Promote buildstation Linktree CTA update to main

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,6 +9,8 @@ export const REGISTER_BUILD_STATION_DEMO_DAY_LINK =
 export const PROJECT_SUBMISSION_LINK = "https://tally.so/r/mD5Q7X";
 export const UPCOMING_HACKATHON_LINK =
   "https://arena.colosseum.org/?ref=germany";
+export const HACKATHON_LINKTREE_LINK =
+  "https://linktr.ee/superteamhackathon";
 
 // Locations
 export const WEB3_HUB_LOCATION_LINK = "https://goo.gl/maps/bsnPMX1QNZ1Bxa7w8";

--- a/src/sections/buildstation/hero.tsx
+++ b/src/sections/buildstation/hero.tsx
@@ -9,7 +9,11 @@ import { NewsletterGroup } from "@/types/enum";
 import { Container } from "@/components/container";
 import { Button } from "@/components/button";
 import NewsletterSection from "../home/newsletter-section";
-import { UPCOMING_HACKATHON_LINK } from "@/lib/constants";
+import Link from "next/link";
+import {
+  HACKATHON_LINKTREE_LINK,
+  UPCOMING_HACKATHON_LINK,
+} from "@/lib/constants";
 
 export default function Hero() {
   const images = [
@@ -84,29 +88,14 @@ export default function Hero() {
                 >
                   Register for Build Station
                 </Button>
-
-                <Button
-                  variant="outline"
-                  onClick={() =>
-                    window.open(
-                      "https://superteamdao.notion.site/colosseum-hackathon-2025",
-                      "_blank"
-                    )
-                  }
+                <Link
+                  href={HACKATHON_LINKTREE_LINK}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-center font-secondary tracking-wide font-normal text-base underline underline-offset-4 hover:opacity-80"
                 >
-                  Complete Guide
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() =>
-                    window.open(
-                      "https://superteamdao.notion.site/colosseum-hackathon-2025#1e8794d3ba3380a7bfe1d2428dd4db04",
-                      "_blank"
-                    )
-                  }
-                >
-                  Book your 1:1 Mentoring
-                </Button>
+                  More Hackathon Info
+                </Link>
               </div>
             </div>
             <div className="pt-20 lg:row-span-2 lg:-mr-16 xl:mr-auto">


### PR DESCRIPTION
## Summary
Promote the buildstation Linktree CTA update from `development` to `main`.

## Includes
- removed stale guide and mentoring links from the buildstation hero
- added a new Linktree-based hackathon information CTA
