### PR TITLE
Promote buildstation resource link updates to main

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -9,6 +9,8 @@ export const REGISTER_BUILD_STATION_DEMO_DAY_LINK =
 export const PROJECT_SUBMISSION_LINK = "https://tally.so/r/mD5Q7X";
 export const UPCOMING_HACKATHON_LINK =
   "https://arena.colosseum.org/?ref=germany";
+export const HACKATHON_GUIDE_LINK =
+  "https://superteamdao.notion.site/colosseum-hackathon-2025#1e8794d3ba3380a7bfe1d2428dd4db04";
 export const HACKATHON_LINKTREE_LINK =
   "https://linktr.ee/superteamhackathon";
 

--- a/src/sections/buildstation/hero.tsx
+++ b/src/sections/buildstation/hero.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/button";
 import NewsletterSection from "../home/newsletter-section";
 import Link from "next/link";
 import {
+  HACKATHON_GUIDE_LINK,
   HACKATHON_LINKTREE_LINK,
   UPCOMING_HACKATHON_LINK,
 } from "@/lib/constants";
@@ -88,6 +89,14 @@ export default function Hero() {
                 >
                   Register for Build Station
                 </Button>
+                <Link
+                  href={HACKATHON_GUIDE_LINK}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-center font-secondary tracking-wide font-normal text-base underline underline-offset-4 hover:opacity-80"
+                >
+                  Hackathon Guide
+                </Link>
                 <Link
                   href={HACKATHON_LINKTREE_LINK}
                   target="_blank"


### PR DESCRIPTION
## Summary
Promote the buildstation resource link updates from `development` to `main`.

## Includes
- updated buildstation hero resource links
- Hackathon Guide link
- Linktree-based hackathon info link
- footer docs label cleanup if included in the development branch
