### PR TITLE
Release Solana Summit Germany

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -181,6 +181,41 @@
     @apply bg-gradient-to-r from-[#9945ff] via-[#b9ffe7] to-[#14f195] bg-clip-text text-transparent;
   }
 
+  .summit-hero-copy {
+    animation: summit-hero-copy-in 1200ms cubic-bezier(0.16, 1, 0.3, 1) 160ms both;
+  }
+
+  .summit-scroll-reveal {
+    opacity: 1;
+    transform: none;
+  }
+
+  .summit-scroll-reveal.is-ready {
+    opacity: 0;
+    transform: translateY(22px);
+    transition:
+      opacity 1200ms cubic-bezier(0.16, 1, 0.3, 1),
+      transform 1200ms cubic-bezier(0.16, 1, 0.3, 1);
+    will-change: opacity, transform;
+  }
+
+  .summit-scroll-reveal.is-ready.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    will-change: auto;
+  }
+
+  @keyframes summit-hero-copy-in {
+    from {
+      opacity: 0;
+      transform: translateY(18px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
   .summit-outline-cta {
     border: 1px solid rgba(20, 241, 149, 0.55);
     background:
@@ -331,6 +366,19 @@
       background:
         radial-gradient(ellipse at 50% 50%, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.62) 52%, rgba(0, 0, 0, 0.9) 100%),
         linear-gradient(to bottom, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.22) 45%, rgba(0, 0, 0, 0.82));
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .summit-hero-copy {
+      animation: none;
+    }
+
+    .summit-scroll-reveal {
+      opacity: 1;
+      transform: none;
+      transition: none;
+      will-change: auto;
     }
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,9 @@ export const metadata: Metadata = {
   description:
     "Uniting the power of innovation, creativity, and collaboration to shape the Solana Ecosystem in Germany.",
   icons: {
-    icon: "/st-flag-logo.png",
+    icon: [{ url: "/st-flag-logo.png", type: "image/png" }],
+    shortcut: [{ url: "/st-flag-logo.png", type: "image/png" }],
+    apple: [{ url: "/st-flag-logo.png", type: "image/png" }],
   },
   openGraph: {
     title: "Superteam Germany",

--- a/src/app/solana-summit-germany/agenda/page.tsx
+++ b/src/app/solana-summit-germany/agenda/page.tsx
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
   title: "Agenda | Solana Summit Germany",
   description:
     "Explore the placeholder agenda for Solana Summit Germany in Berlin on 13 June 2026.",
+  icons: {
+    icon: [{ url: "/st-flag-logo.png", type: "image/png" }],
+    shortcut: [{ url: "/st-flag-logo.png", type: "image/png" }],
+    apple: [{ url: "/st-flag-logo.png", type: "image/png" }],
+  },
   openGraph: {
     title: "Solana Summit Germany Agenda",
     description:

--- a/src/app/solana-summit-germany/page.tsx
+++ b/src/app/solana-summit-germany/page.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/constants";
 import { faqs } from "@/sections/solana-summit/data";
 import { SummitReveal } from "@/sections/solana-summit/summit-reveal";
+import { SummitScrollReveal } from "@/sections/solana-summit/summit-scroll-reveal";
 import { SpeakerGrid } from "@/sections/solana-summit/speaker-grid";
 import { SummitCta } from "@/sections/solana-summit/summit-cta";
 import { SummitNav, SummitShell } from "@/sections/solana-summit/summit-shell";
@@ -117,6 +118,11 @@ export const metadata: Metadata = {
   title: "Solana Summit Germany | Superteam Germany",
   description:
     "Join Solana Summit Germany in Berlin on 13 June 2026 for talks, networking, live formats, and the German Solana ecosystem.",
+  icons: {
+    icon: [{ url: "/st-flag-logo.png", type: "image/png" }],
+    shortcut: [{ url: "/st-flag-logo.png", type: "image/png" }],
+    apple: [{ url: "/st-flag-logo.png", type: "image/png" }],
+  },
   openGraph: {
     title: "Solana Summit Germany",
     description:
@@ -187,7 +193,7 @@ function Hero() {
       <SummitNav className="absolute inset-x-0 top-0" />
       <SummitSidePatterns className="summit-hero-side-patterns" />
       <SummitHeroSilhouette priority />
-      <div className="summit-container relative z-10 flex min-h-screen flex-col items-center justify-center text-center">
+      <div className="summit-hero-copy summit-container relative z-10 flex min-h-screen flex-col items-center justify-center text-center">
         <p className="text-[22px] font-normal leading-none text-[#14f195] drop-shadow-[0_6px_24px_rgba(0,0,0,0.85)] md:text-[30px]">
           13 June 2026 / Berlin
         </p>
@@ -222,7 +228,7 @@ function EventDetails() {
           <h2 className="summit-section-heading">Event details</h2>
           <div className="summit-divider" />
           <div className="grid gap-10 lg:grid-cols-[520px_1fr] lg:gap-14">
-            <div className="border-t border-white/10 lg:border-t-0">
+            <div>
               {detailRows.map((fact) => (
                 <div
                   key={fact.label}
@@ -445,6 +451,14 @@ function GettingThere() {
                 </p>
                 <div className="mt-4 flex flex-col items-start gap-3 text-[20px] leading-snug text-[#aaa7b5] md:text-[22px]">
                   <a
+                    href="https://www.nhow-hotels.com/en/nhow-berlin"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="transition-colors duration-150 ease-out hover:text-[#14f195] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#14f195] focus-visible:ring-offset-4 focus-visible:ring-offset-black"
+                  >
+                    Hotel nhow Berlin
+                  </a>
+                  <a
                     href="https://www.michelbergerhotel.com/en/rooms"
                     target="_blank"
                     rel="noopener noreferrer"
@@ -474,7 +488,7 @@ function FinalCta() {
   return (
     <SummitReveal className="summit-final-stage relative overflow-hidden bg-black px-6 py-28 text-center lg:py-36">
       <SummitSidePatterns className="summit-final-side-patterns" />
-      <div className="relative z-10 mx-auto max-w-[960px]">
+      <SummitScrollReveal className="relative z-10 mx-auto max-w-[960px]">
         <h2 className="text-[56px] font-light leading-[1.03] tracking-[-0.015em] text-[#aaa7b5] md:text-[88px]">
           Don&apos;t miss
           <br />
@@ -492,7 +506,7 @@ function FinalCta() {
           height={24}
           className="mx-auto mt-10 h-auto w-[142px] opacity-70 md:mt-12 md:w-[170px]"
         />
-      </div>
+      </SummitScrollReveal>
     </SummitReveal>
   );
 }

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -31,6 +31,11 @@ const menuItems = [
   },
 ];
 
+const summitCta = {
+  name: "Solana Summit Germany",
+  link: "/solana-summit-germany",
+};
+
 const Nav = () => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -103,15 +108,19 @@ const Nav = () => {
               })}
               <li>
                 <div className="py-8"></div>
-                <Link
-                  href="https://twitter.com/SuperteamDE"
-                  target="_blank"
-                  rel="noopener noreferrer"
+                <Button
+                  asChild
+                  className="whitespace-nowrap font-secondary text-base font-normal tracking-wide no-underline hover:opacity-100"
                 >
-                  <Button className="font-secondary tracking-wide font-normal text-base">
-                    Follow us on X
-                  </Button>
-                </Link>
+                  <Link
+                    href={summitCta.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => setIsOpen(false)}
+                  >
+                    {summitCta.name}
+                  </Link>
+                </Button>
               </li>
             </motion.ul>
           )}
@@ -144,15 +153,18 @@ const Nav = () => {
             }
           })}
           <li>
-            <Link
-              href="https://twitter.com/SuperteamDE"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Button
+              asChild
+              className="whitespace-nowrap font-secondary text-base font-normal tracking-wide no-underline hover:opacity-100"
             >
-              <Button className="font-secondary tracking-wide font-normal text-base">
-                Follow us on X
-              </Button>
-            </Link>
+              <Link
+                href={summitCta.link}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {summitCta.name}
+              </Link>
+            </Button>
           </li>
         </ul>
       </div>

--- a/src/sections/home/hero.tsx
+++ b/src/sections/home/hero.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 import { useScroll, useTransform } from 'framer-motion';
 import { Button } from '@/components/button';
 import Link from 'next/link';
-import { UPCOMING_HACKATHON_LINK } from '@/lib/constants';
+import { SOLANA_SUMMIT_LUMA_LINK } from '@/lib/constants';
 
 export default function Example() {
   const { scrollYProgress } = useScroll();
@@ -69,40 +69,52 @@ export default function Example() {
                 <span className='text-shadow'>The Heartbeat of Germany&apos;s Solana Community</span>
               </h1>
               <p className="mt-6 sm:max-w-md lg:max-w-none text-white/85">
-                Register for the Colosseum Global Hackathon through Superteam
-                Germany and build with founder, mentor, and community support
-                from our network across Germany.
+                Join Germany&rsquo;s largest Solana conference &mdash; a one-day
+                Berlin summit for founders, developers, investors,
+                institutions, and creators shaping Internet Capital Markets.
               </p>
               <div className="mt-6 flex flex-col items-start gap-2 text-sm text-white/80 sm:hidden">
                 <span className="rounded-full border border-white/10 bg-white/5 px-4 py-2 backdrop-blur">
-                  06.04–11.05.2026 Hackathon
+                  13 June 2026 / Berlin
                 </span>
                 <span className="rounded-full border border-white/10 bg-white/5 px-4 py-2 backdrop-blur">
-                  27.04–11.05 Buildstation Berlin
+                  Internet Capital Markets
                 </span>
                 <span className="rounded-full border border-white/10 bg-white/5 px-4 py-2 backdrop-blur">
-                  12.05 Demo Day
+                  Talks, Networking &amp; Community
                 </span>
               </div>
               <div className="mt-6 hidden rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/80 backdrop-blur sm:inline-flex sm:flex-wrap sm:items-center sm:gap-2">
-                <span>06.04–11.05.2026 Hackathon</span>
+                <span>13 June 2026 / Berlin</span>
                 <span className="text-white/30">•</span>
-                <span>27.04–11.05 Buildstation Berlin</span>
+                <span>Internet Capital Markets</span>
                 <span className="text-white/30">•</span>
-                <span>12.05 Demo Day</span>
+                <span>Talks, Networking &amp; Community</span>
               </div>
               <div className="mt-10 flex flex-col gap-4 sm:flex-row sm:items-center">
                 <Button
-                  onClick={() => window.open(UPCOMING_HACKATHON_LINK, '_blank')}
+                  asChild
                   className="font-secondary tracking-wide font-normal text-base"
                 >
-                  Register for the Hackathon
+                  <Link
+                    href={SOLANA_SUMMIT_LUMA_LINK}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="no-underline hover:opacity-100"
+                  >
+                    <span className="sm:hidden">Register now</span>
+                    <span className="hidden sm:inline">
+                      Register for Solana Summit
+                    </span>
+                  </Link>
                 </Button>
                 <Link
-                  href="/buildstation"
-                  className="font-secondary tracking-wide font-normal text-base underline underline-offset-4 hover:opacity-80 sm:ml-2"
+                  href="/solana-summit-germany"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex h-10 w-full items-center justify-center rounded-[var(--radius)] border border-white/15 bg-white/5 px-4 py-2 font-secondary text-base font-normal tracking-wide text-white no-underline shadow-xl backdrop-blur-sm transition-colors hover:bg-white/10 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:w-auto"
                 >
-                  See hackathon details
+                  See Summit Details
                 </Link>
               </div>
             </div>

--- a/src/sections/solana-summit/data.ts
+++ b/src/sections/solana-summit/data.ts
@@ -123,10 +123,28 @@ export const agendaItems: AgendaItem[] = [
     section: "Opening",
   },
   {
-    time: "TBD",
-    title: "Sessions TBD",
-    type: "TBD",
-    speakers: [],
+    time: "11:40 - 12:20",
+    title:
+      "Built in America, Validated in Europe: // Public Chain, Private Stack: Who Controls Solana's Infrastructure?",
+    type: "Panel",
+    speakers: ["TBA"],
+    location: "Main Stage",
+    section: "Onchain Capital Markets",
+  },
+  {
+    time: "12:20 - 12:35",
+    title:
+      "Stablecoin innovation: MiCA, EURC, and the European Stablecoin Race",
+    type: "Fireside Chat",
+    speakers: ["AllUnity"],
+    location: "Main Stage",
+    section: "Onchain Capital Markets",
+  },
+  {
+    time: "12:35 - 13:05",
+    title: "The RWA Boom: tokenized assets on Solana",
+    type: "Panel",
+    speakers: ["TBA"],
     location: "Main Stage",
     section: "Onchain Capital Markets",
   },

--- a/src/sections/solana-summit/summit-scroll-reveal.tsx
+++ b/src/sections/solana-summit/summit-scroll-reveal.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+type SummitScrollRevealProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function SummitScrollReveal({
+  children,
+  className,
+}: SummitScrollRevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isReady, setIsReady] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+
+    if (!node) {
+      return;
+    }
+
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    if (prefersReducedMotion || !("IntersectionObserver" in window)) {
+      setIsVisible(true);
+      return;
+    }
+
+    setIsReady(true);
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      {
+        rootMargin: "0px 0px -12% 0px",
+        threshold: 0.2,
+      },
+    );
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={`${className ?? ""} summit-scroll-reveal ${
+        isReady ? "is-ready" : ""
+      } ${
+        isVisible ? "is-visible" : ""
+      }`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/sections/solana-summit/summit-shell.tsx
+++ b/src/sections/solana-summit/summit-shell.tsx
@@ -42,7 +42,7 @@ export function SummitNav({
             alt="Solana Summit Germany"
             width={500}
             height={500}
-            className="h-[91px] w-[204px] object-cover object-center lg:h-[104px] lg:w-[232px]"
+            className="h-[82px] w-[184px] object-cover object-center sm:h-[91px] sm:w-[204px] lg:h-[104px] lg:w-[232px]"
             priority
           />
         </Link>


### PR DESCRIPTION
Release the Solana Summit Germany landing and agenda pages
- Add homepage registration and Summit detail CTAs
- Include updated Summit content, partners, speakers, agenda, metadata, and responsive polish

Verification:
- yarn build passed on development