### PR TITLE
release: summit social preview X cache fix

### DIFF
--- a/src/app/solana-summit-germany/agenda-preview/page.tsx
+++ b/src/app/solana-summit-germany/agenda-preview/page.tsx
@@ -10,7 +10,7 @@ import { SummitNav, SummitShell } from "@/sections/solana-summit/summit-shell";
 const agendaPreviewUrl =
   "https://www.superteamde.fun/solana-summit-germany/agenda-preview";
 const summitSocialImage =
-  "https://www.superteamde.fun/images/summit-germany/summit-x-website-link-view.png";
+  "https://www.superteamde.fun/images/summit-germany/summit-x-website-link-view.png?v=2";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.superteamde.fun"),

--- a/src/app/solana-summit-germany/page.tsx
+++ b/src/app/solana-summit-germany/page.tsx
@@ -123,7 +123,7 @@ const partnerRows = [
 
 const summitUrl = "https://www.superteamde.fun/solana-summit-germany";
 const summitSocialImage =
-  "https://www.superteamde.fun/images/summit-germany/summit-x-website-link-view.png";
+  "https://www.superteamde.fun/images/summit-germany/summit-x-website-link-view.png?v=2";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.superteamde.fun"),


### PR DESCRIPTION
## Summary
Promotes the X social preview cache-buster from `development` to `main`.
