### PR TITLE
Update Summit side events and speaker details

### DIFF
--- a/src/sections/solana-summit/data.ts
+++ b/src/sections/solana-summit/data.ts
@@ -233,7 +233,7 @@ export const agendaItems: AgendaItem[] = [
     time: "14:25 - 14:40",
     title: "Where CEXs Meet Onchain Perps: Phoenix, Hyperliquid & OKX",
     type: "Fireside Chat",
-    speakers: ["TBA"],
+    speakers: ["Chris Grundy (OKX)", "Merdan Aslan (Superteam Germany)"],
     location: "Main Stage",
     section: "Onchain Capital Markets",
     status: "confirmed",

--- a/src/sections/solana-summit/speaker-grid.tsx
+++ b/src/sections/solana-summit/speaker-grid.tsx
@@ -138,8 +138,8 @@ const speakerCards: SpeakerCard[] = [
   {
     name: "Ulrike",
     surname: "Lierow Schad",
-    company: "CVVC / Bundesblock",
-    role: "MD Berlin - CV Labs | Politics - Bundesblock",
+    company: "Bundesblock",
+    role: "Head of Public Affairs & Partnerships",
     image: "/images/summit-germany/ulrikel.jpeg",
   },
   {
@@ -416,7 +416,7 @@ const speakerCards: SpeakerCard[] = [
   {
     name: "Robert Michael",
     surname: "Jones",
-    company: "Jito",
+    company: "SolanaFloor",
     role: "Head of Partnerships",
     image: "/images/summit-germany/Robert-Jones.jpeg",
   },


### PR DESCRIPTION
## Summary
- Added OKX Summit and No Illusions to the side events page
- Added Samantha Merlivat as a speaker with the new speaker image
- Updated João Martins’ speaker image
- Updated Robert Michael Jones to SolanaFloor
- Updated Ulrike Lierow Schad’s company and title
- Added Chris Grundy and Merdan Aslan to the perps fireside agenda session

## Verification
- Ran `git diff --check`
- Ran `nvm use && yarn build`